### PR TITLE
build with yarn

### DIFF
--- a/geth-with-protocol/build-protocol.sh
+++ b/geth-with-protocol/build-protocol.sh
@@ -1,4 +1,4 @@
-npm install -g truffle
+npm install -g truffle yarn
 mkdir /psrc && cd /psrc
 
 git clone https://github.com/livepeer/protocol.git
@@ -76,13 +76,13 @@ module.exports = async () => {
 }
 EOF
 
-echo "npm install"
-npm install
+echo "yarn install"
+yarn
 echo "Complinig protocol..."
-npm run compile
+yarn run compile
 echo "Complie done, deploying"
 
-nohup bash -c "/start.sh &" && 
+nohup bash -c "/start.sh &" &&
 sleep 1
 
 OPWD=$PWD
@@ -100,7 +100,7 @@ controllerAddress=$(cd $srcDir/protocol && truffle networks | awk '/54321/{f=1;n
 echo "Controller address: $controllerAddress"
 truffle networks
 truffle networks > $gethRoot/networks
-echo $controllerAddress > $getRoot/controllerAddress
+echo $controllerAddress > $gethRoot/controllerAddress
 cd $OPWD
 sleep 3
 # now we need to wait till 100 block mined (so current protocol round will be 2)


### PR DESCRIPTION
the `build-protocol.sh` was failing on the node container, yarn seems to work fine though.

there is also a small syntax fix.