### PR TITLE
WIP: Changes for AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+# This is the one with Docker
+image: Visual Studio 2017
+
+# Test against the latest version of this Node.js version
+environment:
+  nodejs_version: "10"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install -g yarn
+  - yarn install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - docker login -u %DOCKER_USER% -p %DOCKER_PASS%
+  - cd ffmpeg
+  - docker build -m 4gb -t iameli/livepeer-ffmpeg-base -f .\Dockerfile.ffmpeg-windows .
+  - docker push iameli/livepeer-ffmpeg-base
+
+# Don't actually build.
+build: off

--- a/ffmpeg/Dockerfile.ffmpeg-windows
+++ b/ffmpeg/Dockerfile.ffmpeg-windows
@@ -6,7 +6,7 @@
 # docker build -m 4gb -t livepeer/ffmpeg-base:windows -f Dockerfile.ffmpeg-windows .
 # docker push livepeer/ffmpeg-base:windows
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2019 as builder
+FROM mcr.microsoft.com/windows/servercore:ltsc2016 as builder
 
 
 WORKDIR c:/temp
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -UserAgent 'DockerCI' -outfile 7zsetup.exe http://www.7-zi
 RUN Start-Process .\7zsetup -ArgumentList '/S /D=c:/7zip' -Wait
 
 RUN (new-object System.Net.WebClient).DownloadFile('http://repo.msys2.org/distrib/msys2-x86_64-latest.tar.xz','C:\temp\msys2-x86_64-latest.tar.xz')
-RUN Get-FileHash -Path msys2-x86_64-latest.tar.xz 
+RUN Get-FileHash -Path msys2-x86_64-latest.tar.xz
 RUN C:\7zip\7z e msys2-x86_64-latest.tar.xz -Wait
 RUN C:\7zip\7z x msys2-x86_64-latest.tar -o"C:\\"
 

--- a/ffmpeg/Dockerfile.ffmpeg-windows
+++ b/ffmpeg/Dockerfile.ffmpeg-windows
@@ -11,7 +11,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016 as builder
 
 WORKDIR c:/temp
 
-# SHELL ["powershell", "-Command"]
+SHELL ["powershell", "-Command"]
 
 # Download and extract MSYS2 with 7zip.
 
@@ -27,31 +27,31 @@ RUN C:\7zip\7z x msys2-x86_64-latest.tar -o"C:\\"
 # Install MSYS2 and our required packages
 
 RUN Write-Host 'Updating MSYSTEM and MSYSCON ...'; `
-    [Environment]::SetEnvironmentVariable('MSYSTEM', 'MSYS2', [EnvironmentVariableTarget]::Machine); `
-    [Environment]::SetEnvironmentVariable('MSYSCON', 'defterm', [EnvironmentVariableTarget]::Machine);
+  [Environment]::SetEnvironmentVariable('MSYSTEM', 'MSYS2', [EnvironmentVariableTarget]::Machine); `
+  [Environment]::SetEnvironmentVariable('MSYSCON', 'defterm', [EnvironmentVariableTarget]::Machine);
 
 RUN C:\msys64\usr\bin\bash.exe -l -c 'exit 0'; `
-    C:\msys64\usr\bin\bash.exe -l -c 'echo "Now installing MSYS2..."'; `
-    C:\msys64\usr\bin\bash.exe -l -c 'pacman -Syuu --needed --noconfirm --noprogressbar --ask=20'; `
-    C:\msys64\usr\bin\bash.exe -l -c 'pacman -Syu  --needed --noconfirm --noprogressbar --ask=20'; `
-    C:\msys64\usr\bin\bash.exe -l -c 'pacman -Su   --needed --noconfirm --noprogressbar --ask=20'; `
-    # Install our packages. Use the mingw-w64-x86_64 version of everything run-time; MSYS2 is apparently slower?
-    C:\msys64\usr\bin\bash.exe -l -c 'pacman -S perl binutils git make autoconf mingw-w64-x86_64-gcc mingw-w64-x86_64-libtool mingw-w64-x86_64-gnutls mingw-w64-x86_64-go mingw-w64-x86_64-pkg-config --noconfirm --noprogressbar --ask=20'; `
-    C:\msys64\usr\bin\bash.exe -l -c 'pacman -Scc --noconfirm'; `
-    C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully installed MSYS2"'; `
-    # MSYS2 leaves processes running or something - this step hangs? Hard shutdown to fix that.
-    Stop-Computer -Force
+  C:\msys64\usr\bin\bash.exe -l -c 'echo "Now installing MSYS2..."'; `
+  C:\msys64\usr\bin\bash.exe -l -c 'pacman -Syuu --needed --noconfirm --noprogressbar --ask=20'; `
+  C:\msys64\usr\bin\bash.exe -l -c 'pacman -Syu  --needed --noconfirm --noprogressbar --ask=20'; `
+  C:\msys64\usr\bin\bash.exe -l -c 'pacman -Su   --needed --noconfirm --noprogressbar --ask=20'; `
+  # Install our packages. Use the mingw-w64-x86_64 version of everything run-time; MSYS2 is apparently slower?
+  C:\msys64\usr\bin\bash.exe -l -c 'pacman -S perl binutils git make autoconf mingw-w64-x86_64-gcc mingw-w64-x86_64-libtool mingw-w64-x86_64-gnutls mingw-w64-x86_64-go mingw-w64-x86_64-pkg-config --noconfirm --noprogressbar --ask=20'; `
+  C:\msys64\usr\bin\bash.exe -l -c 'pacman -Scc --noconfirm'; `
+  C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully installed MSYS2"'; `
+  # MSYS2 leaves processes running or something - this step hangs? Hard shutdown to fix that.
+  Stop-Computer -Force
 
 # Install FFMpeg, nasm, x264
 ADD install_ffmpeg_windows.sh c:\temp\install_ffmpeg_windows.sh
 ADD install_ffmpeg.sh c:\temp\install_ffmpeg.sh
 
 RUN  C:\msys64\usr\bin\bash.exe -l -c '/c/temp/install_ffmpeg_windows.sh '; `
-     C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully complided ffmpeg lib"';
+  C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully complided ffmpeg lib"';
 
 RUN Remove-Item @('C:\msys64\build\x264') -Force -Recurse; `
-    Remove-Item @('C:\msys64\build\nasm') -Force -Recurse; `
-    Remove-Item @('C:\msys64\build\ffmpeg') -Force -Recurse;
+  Remove-Item @('C:\msys64\build\nasm') -Force -Recurse; `
+  Remove-Item @('C:\msys64\build\ffmpeg') -Force -Recurse;
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 

--- a/ffmpeg/Dockerfile.ffmpeg-windows
+++ b/ffmpeg/Dockerfile.ffmpeg-windows
@@ -38,9 +38,9 @@ RUN C:\msys64\usr\bin\bash.exe -l -c 'exit 0'; `
   # Install our packages. Use the mingw-w64-x86_64 version of everything run-time; MSYS2 is apparently slower?
   C:\msys64\usr\bin\bash.exe -l -c 'pacman -S perl binutils git make autoconf mingw-w64-x86_64-gcc mingw-w64-x86_64-libtool mingw-w64-x86_64-gnutls mingw-w64-x86_64-go mingw-w64-x86_64-pkg-config --noconfirm --noprogressbar --ask=20'; `
   C:\msys64\usr\bin\bash.exe -l -c 'pacman -Scc --noconfirm'; `
-  C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully installed MSYS2"'; `
-  # MSYS2 leaves processes running or something - this step hangs? Hard shutdown to fix that.
-  Stop-Computer -Force
+  C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully installed MSYS2"';
+# MSYS2 leaves processes running or something - this step hangs? Hard shutdown to fix that.
+# Stop-Computer -Force
 
 # Install FFMpeg, nasm, x264
 ADD install_ffmpeg_windows.sh c:\temp\install_ffmpeg_windows.sh

--- a/ffmpeg/Dockerfile.ffmpeg-windows
+++ b/ffmpeg/Dockerfile.ffmpeg-windows
@@ -47,7 +47,8 @@ RUN C:\msys64\usr\bin\bash.exe -l -c 'exit 0'; `
 ADD install_ffmpeg_windows.sh c:\temp\install_ffmpeg_windows.sh
 ADD install_ffmpeg.sh c:\temp\install_ffmpeg.sh
 
-RUN  C:\msys64\usr\bin\bash.exe -l -c '/c/temp/install_ffmpeg_windows.sh '; `
+RUN C:\msys64\usr\bin\bash.exe -l -c 'exit 0'; `
+  C:\msys64\usr\bin\bash.exe -l -c '/c/temp/install_ffmpeg_windows.sh '; `
   C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully complided ffmpeg lib"';
 
 RUN Remove-Item @('C:\msys64\build\x264') -Force -Recurse; `

--- a/ffmpeg/Dockerfile.ffmpeg-windows
+++ b/ffmpeg/Dockerfile.ffmpeg-windows
@@ -38,7 +38,8 @@ RUN C:\msys64\usr\bin\bash.exe -l -c 'exit 0'; `
   # Install our packages. Use the mingw-w64-x86_64 version of everything run-time; MSYS2 is apparently slower?
   C:\msys64\usr\bin\bash.exe -l -c 'pacman -S perl binutils git make autoconf mingw-w64-x86_64-gcc mingw-w64-x86_64-libtool mingw-w64-x86_64-gnutls mingw-w64-x86_64-go mingw-w64-x86_64-pkg-config --noconfirm --noprogressbar --ask=20'; `
   C:\msys64\usr\bin\bash.exe -l -c 'pacman -Scc --noconfirm'; `
-  C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully installed MSYS2"';
+  C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully installed MSYS2"'; `
+  Get-Process
 # MSYS2 leaves processes running or something - this step hangs? Hard shutdown to fix that.
 # Stop-Computer -Force
 

--- a/ffmpeg/Dockerfile.ffmpeg-windows
+++ b/ffmpeg/Dockerfile.ffmpeg-windows
@@ -11,7 +11,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016 as builder
 
 WORKDIR c:/temp
 
-SHELL ["powershell", "-Command"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Download and extract MSYS2 with 7zip.
 

--- a/ffmpeg/Dockerfile.ffmpeg-windows
+++ b/ffmpeg/Dockerfile.ffmpeg-windows
@@ -30,6 +30,9 @@ RUN Write-Host 'Updating MSYSTEM and MSYSCON ...'; `
   [Environment]::SetEnvironmentVariable('MSYSTEM', 'MSYS2', [EnvironmentVariableTarget]::Machine); `
   [Environment]::SetEnvironmentVariable('MSYSCON', 'defterm', [EnvironmentVariableTarget]::Machine);
 
+ADD install_ffmpeg_windows.sh c:\temp\install_ffmpeg_windows.sh
+ADD install_ffmpeg.sh c:\temp\install_ffmpeg.sh
+
 RUN C:\msys64\usr\bin\bash.exe -l -c 'exit 0'; `
   C:\msys64\usr\bin\bash.exe -l -c 'echo "Now installing MSYS2..."'; `
   C:\msys64\usr\bin\bash.exe -l -c 'pacman -Syuu --needed --noconfirm --noprogressbar --ask=20'; `
@@ -39,23 +42,25 @@ RUN C:\msys64\usr\bin\bash.exe -l -c 'exit 0'; `
   C:\msys64\usr\bin\bash.exe -l -c 'pacman -S perl binutils git make autoconf mingw-w64-x86_64-gcc mingw-w64-x86_64-libtool mingw-w64-x86_64-gnutls mingw-w64-x86_64-go mingw-w64-x86_64-pkg-config --noconfirm --noprogressbar --ask=20'; `
   C:\msys64\usr\bin\bash.exe -l -c 'pacman -Scc --noconfirm'; `
   C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully installed MSYS2"'; `
-  Get-Process
+  C:\msys64\usr\bin\bash.exe -l -c '/c/temp/install_ffmpeg_windows.sh '; `
+  C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully complided ffmpeg lib"';
 # MSYS2 leaves processes running or something - this step hangs? Hard shutdown to fix that.
 # Stop-Computer -Force
 
 # Install FFMpeg, nasm, x264
-ADD install_ffmpeg_windows.sh c:\temp\install_ffmpeg_windows.sh
-ADD install_ffmpeg.sh c:\temp\install_ffmpeg.sh
+# ADD install_ffmpeg_windows.sh c:\temp\install_ffmpeg_windows.sh
+# ADD install_ffmpeg.sh c:\temp\install_ffmpeg.sh
 
-RUN C:\msys64\usr\bin\bash.exe -l -c 'exit 0'; `
-  C:\msys64\usr\bin\bash.exe -l -c '/c/temp/install_ffmpeg_windows.sh '; `
-  C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully complided ffmpeg lib"';
+# RUN Copy-Item C:\msys64 -Recurse -Destination C:\msys64_copy ; `
+#     Remove-Item @('C:\msys64') -Force -Recurse; `
+#     Rename-Item C:\msys64_copy C:\msys64 ; `
 
-RUN Remove-Item @('C:\msys64\build\x264') -Force -Recurse; `
-  Remove-Item @('C:\msys64\build\nasm') -Force -Recurse; `
-  Remove-Item @('C:\msys64\build\ffmpeg') -Force -Recurse;
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+# RUN Remove-Item @('C:\msys64\build\x264') -Force -Recurse; `
+  # Remove-Item @('C:\msys64\build\nasm') -Force -Recurse; `
+  # Remove-Item @('C:\msys64\build\ffmpeg') -Force -Recurse;
 
-COPY --from=builder c:\msys64 c:\msys64
-COPY --from=builder c:\7zip c:\7zip
+# FROM mcr.microsoft.com/windows/servercore:ltsc2016
+# 
+# COPY --from=builder c:\msys64 c:\msys64
+# COPY --from=builder c:\7zip c:\7zip

--- a/ffmpeg/Dockerfile.ffmpeg-windows
+++ b/ffmpeg/Dockerfile.ffmpeg-windows
@@ -11,7 +11,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016 as builder
 
 WORKDIR c:/temp
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+# SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Download and extract MSYS2 with 7zip.
 

--- a/ffmpeg/Dockerfile.ffmpeg-windows
+++ b/ffmpeg/Dockerfile.ffmpeg-windows
@@ -11,7 +11,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016 as builder
 
 WORKDIR c:/temp
 
-# SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+# SHELL ["powershell", "-Command"]
 
 # Download and extract MSYS2 with 7zip.
 


### PR DESCRIPTION
AppVeyor doesn't have a Visual Studio 2019 image yet (though [I've asked for access to the preview](https://github.com/appveyor/ci/issues/2676)) so we need to use an earlier base image.

I'll flatten this giant pile of commits once I get everything working - just needed to do a lot of trial and error with AppVeyor.

I moved the MSYS2 installation and the ffmpeg building into one step, which is definitely inefficient but otherwise the installed binaries weren't present in `/msys64/usr/bin`? Kept getting `/c/temp/install_ffmpeg.sh: line 8: git: command not found` [such as in this build](https://ci.appveyor.com/project/iameli/docker-livepeer/builds/24525769#L824).

Possible that same bug will occur as soon as I try and use this in go-livepeer, will find out today.