### PR TITLE
geth-with-livepeer-protocol: Misc fixes

### DIFF
--- a/geth-with-protocol/Dockerfile
+++ b/geth-with-protocol/Dockerfile
@@ -12,7 +12,7 @@ RUN cp /geth/keys/* $gethRoot/keystore/
 
 FROM node:8-alpine as builder-node
 ENV gethRoot /root/.ethereum
-ENV GET_MINING_ACCOUNT 87da6a8c6e9eff15d703fc2773e32f6af8dbe301
+ENV GETH_MINING_ACCOUNT 87da6a8c6e9eff15d703fc2773e32f6af8dbe301
 
 RUN apk add --no-cache \
         libstdc++ \
@@ -36,7 +36,7 @@ RUN ./build-protocol.sh
 
 # Now create clean image
 FROM alpine:latest
-ENV GET_MINING_ACCOUNT 87da6a8c6e9eff15d703fc2773e32f6af8dbe301
+ENV GETH_MINING_ACCOUNT 87da6a8c6e9eff15d703fc2773e32f6af8dbe301
 ENV gethRoot /root/.ethereum
 LABEL org.livepeer.controller="0xA1fe753Fe65002C22dDc7eab29A308f73C7B6982"
 
@@ -50,5 +50,5 @@ EXPOSE 8545/tcp
 EXPOSE 8546/tcp
 ENTRYPOINT ./start.sh
 
-# Build Docker image: docker build -t geth-dev .
-# Run: docker run -d -p 8545:8545 -p 8546:8546 --name geth-dev geth-dev
+# Build Docker image: ./build.sh 
+# Run: docker run -d -p 8545:8545 -p 8546:8546 --name geth-with-livepeer-protocol livepeer/geth-with-livepeer-protocol

--- a/geth-with-protocol/README.md
+++ b/geth-with-protocol/README.md
@@ -1,0 +1,19 @@
+# geth-with-protocol
+
+A private, single-node (Geth) PoA Ethereum network with the Livepeer protocol contracts deployed. This project should only be used for testing. 
+
+## Usage
+
+```
+docker run -d -p 8545:8545 -p 8546:8546 --name geth-with-livepeer-protocol livepeer/geth-with-livepeer-protocol:pm
+```
+
+This command will download the latest version of the `livepeer/geth-with-livepeer-protocol:pm` container hosted on [DockerHub](https://hub.docker.com/r/livepeer/geth-with-livepeer-protocol).
+
+## Build
+
+```
+./build.sh
+```
+
+This command will build the Docker image locally.

--- a/geth-with-protocol/build-protocol.sh
+++ b/geth-with-protocol/build-protocol.sh
@@ -1,4 +1,3 @@
-npm install -g truffle
 mkdir /psrc && cd /psrc
 
 git clone -b pm https://github.com/livepeer/protocol.git
@@ -10,8 +9,6 @@ sed -i 's/roundLength:.*$/roundLength: 50,/' $migrations
 sed -i 's/unlockPeriod:.*$/unlockPeriod: 50,/' $migrations
 sed -i 's/numActiveTranscoders:.*$/numActiveTranscoders: 50,/' $migrations
 sed -i 's/numTranscoders:.*$/numTranscoders: 100,/' $migrations
-
-
 
 cat << EOF > $srcDir/protocol/truffle.js
 require("babel-register")
@@ -26,7 +23,7 @@ module.exports = {
             gas: 8000000
         },
         lpTestNet: {
-            from: "0x$GET_MINING_ACCOUNT",
+            from: "0x$GETH_MINING_ACCOUNT",
             host: "localhost",
             port: 8545,
             network_id: 54321,
@@ -52,17 +49,21 @@ echo "Installing local dev version of $srcDir/protocol/scripts/unpauseController
 cat <<EOF > $srcDir/protocol/scripts/unpauseController.js
 const Controller = artifacts.require("Controller")
 
-module.exports = async () => {
+module.exports = async cb => {
     const controller = await Controller.deployed()
-    await controller.unpause()
+    await controller.unpause({from: "0x$GETH_MINING_ACCOUNT"})
+    cb()
 }
 EOF
 
 echo "npm install"
 npm install
-echo "Complinig protocol..."
+echo "Compiling contracts..."
 npm run compile
-echo "Complie done, deploying"
+echo "Done compiling, deploying..."
+
+# Create truffle alias pointing to locally installed version
+alias truffle=./node_modules/.bin/truffle
 
 nohup bash -c "/start.sh &" &&
 sleep 1

--- a/geth-with-protocol/build.sh
+++ b/geth-with-protocol/build.sh
@@ -1,4 +1,2 @@
 #!/bin/bash
-#docker build --rm  -t darkdragon/geth-with-livepeer-protocol:latest .
-docker build --rm  -t darkdragon/geth-with-livepeer-protocol:pm .
-
+docker build --rm -t livepeer/geth-with-livepeer-protocol:pm .

--- a/geth-with-protocol/start.sh
+++ b/geth-with-protocol/start.sh
@@ -1,8 +1,8 @@
 geth -networkid 54321 -rpc -ws \
       -rpcaddr "0.0.0.0" -wsaddr "0.0.0.0" \
       -rpccorsdomain "*" -wsorigins "*" \
-      -rpcapi 'personal,account,eth,web3,net' \
-      -wsapi 'personal,account,eth,web3,net' \
+      -rpcapi 'personal,account,eth,web3,net,txpool,miner,debug' \
+      -wsapi 'personal,account,eth,web3,net,txpool,miner,debug' \
       --unlock 0,1,2,3 \
       --password $gethRoot/password.txt \
       --nodiscover --maxpeers 0 \


### PR DESCRIPTION
- Enable additional Geth management APIs
- Remove extraneous truffle dependency
- Invoke callback in truffle unpause script
- Misc typo fixes
- Added a README
- Updated `build.sh` to build the image under the livepeer namespace

As mentioned in the README, the image can now be pulled from `livepeer/geth-with-livepeer-protocol` on DockerHub.