### PR TITLE
geth with protocol: rpcvhost

### DIFF
--- a/geth-with-protocol/start.sh
+++ b/geth-with-protocol/start.sh
@@ -8,4 +8,5 @@ geth -networkid 54321 -rpc -ws \
       --nodiscover --maxpeers 0 \
       --targetgaslimit 0x8000000 \
       --cache=512 --verbosity 2 \
+      --rpcvhosts "*" \
       -mine


### PR DESCRIPTION
Made it possible to connect to the virtual host set through `aliases` in the generated docker-compose from `test-harness`.

Added flag in `start.sh`:

*   `--rpcvhosts value`   Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. (default: "localhost")

Without this flag we would get `403 Forbidden: invalid host specified ` when trying to connect to the client through a virtual host (eg. `geth:8545` as specified in the `test-harness` ) 