### PR TITLE
geth v1.9.0 upgrade

### DIFF
--- a/geth-with-protocol/Dockerfile
+++ b/geth-with-protocol/Dockerfile
@@ -1,5 +1,4 @@
-# can't use geth 1.8 - it doesn't retain state inside docker container
-FROM ethereum/client-go:v1.7.3 as builder-geth
+FROM ethereum/client-go:v1.9.0 as builder-geth
 
 WORKDIR /
 ENV gethRoot /root/.ethereum
@@ -12,7 +11,7 @@ RUN cp /geth/keys/* $gethRoot/keystore/
 
 FROM node:8-alpine as builder-node
 ENV gethRoot /root/.ethereum
-ENV GETH_MINING_ACCOUNT 87da6a8c6e9eff15d703fc2773e32f6af8dbe301
+ENV GETH_MINING_ACCOUNT 0161e041aad467a890839d5b08b138c1e6373072
 
 RUN apk add --no-cache \
         libstdc++ \
@@ -36,9 +35,9 @@ RUN ./build-protocol.sh
 
 # Now create clean image
 FROM alpine:latest
-ENV GETH_MINING_ACCOUNT 87da6a8c6e9eff15d703fc2773e32f6af8dbe301
+ENV GETH_MINING_ACCOUNT 0161e041aad467a890839d5b08b138c1e6373072
 ENV gethRoot /root/.ethereum
-LABEL org.livepeer.controller="0xA1fe753Fe65002C22dDc7eab29A308f73C7B6982"
+LABEL org.livepeer.controller="0x77A0865438f2EfD65667362D4a8937537CA7a5EF"
 
 COPY --from=builder-node /usr/local/bin/geth /usr/local/bin/
 COPY --from=builder-node $gethRoot $gethRoot/

--- a/geth-with-protocol/start.sh
+++ b/geth-with-protocol/start.sh
@@ -3,9 +3,10 @@ geth -networkid 54321 -rpc -ws \
       -rpccorsdomain "*" -wsorigins "*" \
       -rpcapi 'personal,account,eth,web3,net,txpool,miner,debug' \
       -wsapi 'personal,account,eth,web3,net,txpool,miner,debug' \
-      --unlock 0,1,2,3 \
+      --unlock '0161e041aad467a890839d5b08b138c1e6373072,87da6a8c6e9eff15d703fc2773e32f6af8dbe301,b97de4b8c857e4f6bc354f226dc3249aaee49209,c5065c9eeebe6df2c2284d046bfc906501846c51' \
       --password $gethRoot/password.txt \
       --nodiscover --maxpeers 0 \
       --targetgaslimit 0x8000000 \
-      --cache=512 --verbosity 2 \
-      -mine
+      --cache=512 \
+      -mine -verbosity 2 \
+      --allow-insecure-unlock -gcmode "archive" -syncmode "full" --rpcvhosts="*" \


### PR DESCRIPTION
This PR upgrades the version of geth being used from 1.7.3 to v1.9.1 so that it includes the constantinople hard fork.

- In Dockerfile changed `GETH_MINING_ACCOUNT` env variable to be the correct sealer (`0x0161e0...`) as defined in genesis.json `extradata` field, `0x87da6...` is a funded genesis account but not the sealer. 
- Changed indexed `--unlock` to the explicit address of sealer (can unlock all accounts but is this necessary?) (could also use $GETH_MINING_ACCOUNT now)
- Added `--allow-insecure-unlock` to allow exposing http over RPC with unlocked accounts
- Changed node to full archive node to prevent state pruning ( `--gcmode "archive"` ), introduced in[ geth 1.8.0 ](https://blog.ethereum.org/2018/02/14/geth-1-8-iceberg%C2%B9/) this is what lead to loss of state since last 128 blocks are kept in memory only then they are flushed to disk. In addition changed `syncmode `to `full`
- Added `-rpcvhosts "*"` to allow any DNS rebinding


- Tested by running protocol/pm unit tests against a container running locally
- Tested running test-harness

An image can be found at https://cloud.docker.com/u/vergauwennico/repository/docker/vergauwennico/livepeer-testnet

Fixes #9 