### PR TITLE
geth-with-protocol streamflow branch compatability

### DIFF
--- a/geth-with-protocol/Dockerfile
+++ b/geth-with-protocol/Dockerfile
@@ -9,7 +9,7 @@ RUN echo "" > /geth/password.txt
 RUN geth --datadir $gethRoot init /geth/genesis.json
 RUN cp /geth/keys/* $gethRoot/keystore/
 
-FROM node:8-alpine as builder-node
+FROM node:10-alpine as builder-node
 ENV gethRoot /root/.ethereum
 ENV GETH_MINING_ACCOUNT 0161e041aad467a890839d5b08b138c1e6373072
 

--- a/geth-with-protocol/build-protocol.sh
+++ b/geth-with-protocol/build-protocol.sh
@@ -1,6 +1,6 @@
 mkdir /psrc && cd /psrc
 
-git clone -b pm https://github.com/livepeer/protocol.git
+git clone -b streamflow https://github.com/livepeer/protocol.git
 srcDir=/psrc
 cd $srcDir/protocol
 echo "Setting devenv specific protocol parameters"
@@ -32,7 +32,8 @@ module.exports = {
     },
     compilers: {
         solc: {
-            version: "0.4.25",
+            version: "0.5.11",
+            parser: "solcjs",
             settings: {
                 optimizer: {
                     enabled: true,

--- a/geth-with-protocol/build.sh
+++ b/geth-with-protocol/build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build --rm -t livepeer/geth-with-livepeer-protocol:pm .
+docker build --rm -t livepeer/geth-with-livepeer-protocol:streamflow .


### PR DESCRIPTION
This PR upgrades the geth-with-protocol image to be compatible with the latest changes to `protocol/streamflow`

- upgrade solc to 0.5.11
- upgrade node.js builder image that builds the protocol to v10.16.0 since the repo does not longer seem to be backwards compatible with v8.16.0
- change image output tag to `streamflow`