### PR TITLE
[READY] customizing promtheus command args

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -28,6 +28,11 @@ grafana datasource
 - `LP_PROMETHEUS_ENDPOINT` : a full url of the prometheus endpoint, this defaults to `http://localhost:9090` , but in our kubernetes deployments and docker-compose, this need to be changed
 
 
+### Grafana Envs
+
+All `GF_` prefixed envs are passed to grafana , you can find out more details at the [official grafana docs](https://grafana.com/docs/grafana/latest/installation/configuration/#configure-with-environment-variables)
+
+
 ## Usage examples
 
 ```bash

--- a/monitoring/config-generator/package-lock.json
+++ b/monitoring/config-generator/package-lock.json
@@ -88,6 +88,11 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
+    "js-ini": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/js-ini/-/js-ini-1.1.3.tgz",
+      "integrity": "sha512-alYMVZdbuJoSDhEMGyJVVkgy0r8c1sJ+ErMh66wef1/DvNK1MOlxdyqCQ4PkYx3+0xDs1v/48G9i97YnC9RhNA=="
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",

--- a/monitoring/config-generator/package.json
+++ b/monitoring/config-generator/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "js-ini": "^1.1.3",
     "yaml": "^1.7.2",
     "yargs": "^15.1.0"
   }

--- a/monitoring/config-generator/src/generate.js
+++ b/monitoring/config-generator/src/generate.js
@@ -82,7 +82,7 @@ function saveYaml (outputFolder, name, content) {
 generate()
 
 
-function prometheusConfig (env) {
+function prometheusConfig (params) {
   let obj = {
     global: {
       scrape_interval: '5s',
@@ -92,13 +92,13 @@ function prometheusConfig (env) {
     scrape_configs: []
   }
 
-  if (env && env.mode) {
-    switch (env.mode) {
+  if (params && params.mode) {
+    switch (params.mode) {
       case 'standalone':
         obj.scrape_configs.push({
           job_name: 'livepeer-nodes',
           static_configs: [{
-            targets: env.nodes.split(',')
+            targets: params.nodes.split(',')
           }]
         })
         break
@@ -106,14 +106,14 @@ function prometheusConfig (env) {
         obj.scrape_configs.push({
           job_name: 'livepeer-nodes',
           static_configs: [{
-            targets: env.nodes.split(',')
+            targets: params.nodes.split(',')
           }]
         })
         break
       case 'kubernetes':
-        const namespaces = (env.kubeNamespaces) ? env.kubeNamespaces.split(',') : null
+        const namespaces = (params.kubeNamespaces) ? params.kubeNamespaces.split(',') : null
         obj.scrape_configs = getPromKubeJobs(namespaces)
-        if (env.kubeLongterm) {
+        if (params.kubeLongterm) {
           obj['remote_read'] = [{
             url: 'http://localhost:9201/read',
             remote_timeout: '30s'
@@ -126,7 +126,7 @@ function prometheusConfig (env) {
         }
         break
       default:
-        throw new Error(`mode ${env.mode} does not have a defined prometheus.yml config`)
+        throw new Error(`mode ${params.mode} does not have a defined prometheus.yml config`)
         break
     }
   } else {

--- a/monitoring/config-generator/src/generate.js
+++ b/monitoring/config-generator/src/generate.js
@@ -6,6 +6,7 @@ const fs = require('fs')
 const path = require('path')
 const YAML = require('yaml')
 const yargs = require('yargs')
+const supervisord = require('./supervisord')
 
 
 function generate () {
@@ -36,6 +37,21 @@ function generate () {
       'kube-namespaces': {
         describe: 'comma separated list of namespaces to monitoring in the `kubernetes` deployment, this is needed for certain special deployments, it defaults to an empty array.',
         type: "string"
+      },
+      'prometheus-storagePath': {
+        describe: 'the path to the TSDB folder',
+        default: '/data/promtheus',
+        type: 'string'
+      },
+      'prometheus-prefix': {
+        describe: 'useful for running prometheus GUI as a subpath , example: /prometheus',
+        default: '/',
+        type: 'string'
+      },
+      'prometheus-externalUrl': {
+        describe: 'external URL for the promtheus service',
+        default: 'http://localhost:9090',
+        type: 'string'
       }
     })
     .argv
@@ -48,8 +64,11 @@ function generate () {
 
   const promConfig = prometheusConfig(argv)
   console.log('prom JSON: ', JSON.stringify(promConfig))
+  const supervisordConfig = supervisord.generate(argv)
 
   saveYaml('/etc/prometheus', 'prometheus.yml', promConfig)
+  fs.writeFileSync(path.join('/etc/supervisor.d', 'supervisord.conf'), supervisordConfig)
+
 }
 
 
@@ -58,6 +77,7 @@ function saveYaml (outputFolder, name, content) {
   // console.log(content)
   fs.writeFileSync(path.join(outputFolder, name), YAML.stringify(content))
 }
+
 
 generate()
 

--- a/monitoring/config-generator/src/generate.js
+++ b/monitoring/config-generator/src/generate.js
@@ -113,6 +113,17 @@ function prometheusConfig (env) {
       case 'kubernetes':
         const namespaces = (env.kubeNamespaces) ? env.kubeNamespaces.split(',') : null
         obj.scrape_configs = getPromKubeJobs(namespaces)
+        if (env.kubeLongterm) {
+          obj['remote_read'] = [{
+            url: 'http://localhost:9201/read',
+            remote_timeout: '30s'
+          }]
+
+          obj['remote_write'] = [{
+            url: 'http://localhost:9201/write',
+            remote_timeout: '30s'
+          }]
+        }
         break
       default:
         throw new Error(`mode ${env.mode} does not have a defined prometheus.yml config`)

--- a/monitoring/config-generator/src/generate.js
+++ b/monitoring/config-generator/src/generate.js
@@ -38,6 +38,10 @@ function generate () {
         describe: 'comma separated list of namespaces to monitoring in the `kubernetes` deployment, this is needed for certain special deployments, it defaults to an empty array.',
         type: "string"
       },
+      'kube-longterm': {
+        describe: 'enables longterm storage via PostgreSQL, note that the pg_prometheus, and the postgresql adapter are not included in this bundle',
+        type: "boolean"
+      },
       'prometheus-storagePath': {
         describe: 'the path to the TSDB folder',
         default: '/data/promtheus',

--- a/monitoring/config-generator/src/supervisord.js
+++ b/monitoring/config-generator/src/supervisord.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const fs = require('fs')
+const ini = require('js-ini')
+
+function generate (params, defaults = '/etc/supervisor.d/supervisord.conf') {
+  let obj = ini.parse(fs.readFileSync(defaults, 'utf-8'))
+
+  console.log('ini obj: ', obj)
+
+  // prometheus args
+  if(params) {
+    obj['program:prometheus'].command = `/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=${ params.prometheusStoragePath || '/data/prometheus'} --web.route-prefix=${params.prometheusPrefix || '/'} --web.external-url=${params.prometheusExternalUrl || 'http://localhost:9090/prometheus'} --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles`
+  }
+
+  return ini.stringify(obj)
+}
+
+module.exports = { generate }

--- a/monitoring/supervisord.conf
+++ b/monitoring/supervisord.conf
@@ -3,7 +3,6 @@ nodaemon=true
 
 [program:prometheus]
 directory=/prometheus
-# user=nobody
 command=/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/data/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
this lets the container define prometheus `args` for adding a prefix. this is only required in our kubernetes clusters