### PR TITLE
upgrade geth to 1.9.11 and enable hardforks at block 0

### DIFF
--- a/geth-with-protocol/Dockerfile
+++ b/geth-with-protocol/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.9.3 as builder-geth
+FROM ethereum/client-go:v1.9.11 as builder-geth
 
 WORKDIR /
 ENV gethRoot /root/.ethereum

--- a/geth-with-protocol/Dockerfile
+++ b/geth-with-protocol/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.9.0 as builder-geth
+FROM ethereum/client-go:v1.9.3 as builder-geth
 
 WORKDIR /
 ENV gethRoot /root/.ethereum

--- a/geth-with-protocol/genesis.json
+++ b/geth-with-protocol/genesis.json
@@ -1,13 +1,15 @@
 {
   "config": {
     "chainId": 54321,
-    "homesteadBlock": 1,
-    "eip150Block": 2,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
     "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-    "eip155Block": 3,
-    "eip158Block": 3,
-    "byzantiumBlock": 4,
-    "constantinopleBlock": 5,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
     "clique": {
       "period": 1,
       "epoch": 30000


### PR DESCRIPTION
Upgrade the geth version used to match that of go-livepeer. 

Ran into signature errors with older version. 