### PR TITLE
ganache with livepeer protocol

### DIFF
--- a/ganache-with-protocol/Dockerfile
+++ b/ganache-with-protocol/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:10-alpine as builder-node
+USER root
+WORKDIR /
+
+ENV GANACHE_DB_PATH /ganache_db
+
+RUN apk add --no-cache git python bash make g++
+
+COPY build-ganache.sh build-ganache.sh
+RUN chmod +x build-ganache.sh
+
+# RUN GANACHE
+RUN ./build-ganache.sh
+
+FROM node:10-alpine
+ENV GANACHE_DB_PATH /ganache_db
+
+RUN apk add --no-cache git python bash make g++
+RUN npm i ganache-cli -g
+
+COPY --from=builder-node /ganache_db /ganache_db
+
+EXPOSE 8545/tcp
+
+ENTRYPOINT ganache-cli -k istanbul -l 0x7A1200 -h 0.0.0.0 -a 310 -i 54321 --db $GANACHE_DB_PATH

--- a/ganache-with-protocol/Dockerfile
+++ b/ganache-with-protocol/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:10-alpine as builder-node
-USER root
+# USER root
 WORKDIR /
 
 ENV GANACHE_DB_PATH /ganache_db
@@ -22,4 +22,4 @@ COPY --from=builder-node /ganache_db /ganache_db
 
 EXPOSE 8545/tcp
 
-ENTRYPOINT ganache-cli -k istanbul -l 0x7A1200 -h 0.0.0.0 -a 310 -i 54321 --db $GANACHE_DB_PATH
+ENTRYPOINT ganache-cli -k istanbul -l 0x7A1200 -h 0.0.0.0 -a 310 -i 54321 -d --db $GANACHE_DB_PATH

--- a/ganache-with-protocol/build-ganache.sh
+++ b/ganache-with-protocol/build-ganache.sh
@@ -1,0 +1,90 @@
+git clone -b streamflow https://github.com/livepeer/protocol.git
+cd protocol
+echo "Setting devenv specific protocol parameters"
+migrations="/protocol/migrations/migrations.config.js"
+sed -i 's/roundLength:.*$/roundLength: 50,/' $migrations
+sed -i 's/unlockPeriod:.*$/unlockPeriod: 50,/' $migrations
+sed -i 's/numActiveTranscoders:.*$/numActiveTranscoders: 50,/' $migrations
+sed -i 's/numTranscoders:.*$/numTranscoders: 100,/' $migrations
+
+cat << EOF > /protocol/truffle.js
+require("babel-register")
+require("babel-polyfill")
+
+module.exports = {
+    networks: {
+        development: {
+            host: "localhost",
+            port: 8545,
+            network_id: "54321", // Match any network id
+            gas: 8000000
+        }
+    },
+    compilers: {
+        solc: {
+            version: "0.5.11",
+            parser: "solcjs",
+            settings: {
+                optimizer: {
+                    enabled: true,
+                    runs: 200
+                }
+            }
+        }
+    }
+};
+EOF
+
+echo "Installing local dev version of /protocol/scripts/unpauseController.js"
+
+cat <<EOF > /protocol/scripts/unpauseController.js
+const Controller = artifacts.require("Controller")
+
+module.exports = async cb => {
+    const controller = await Controller.deployed()
+    await controller.unpause()
+    cb()
+}
+EOF
+
+echo "npm install"
+npm install --unsafe-perm
+echo "Compiling contracts..."
+npm run compile
+echo "Done compiling, deploying..."
+
+echo "installing ganache"
+npm i ganache-cli -g --unsafe-perm
+
+# Create truffle alias pointing to locally installed version
+alias truffle=./node_modules/.bin/truffle
+nohup bash -c "ganache-cli -k istanbul -l 0x7A1200 -h 0.0.0.0 -i 54321 --db $GANACHE_DB_PATH &" &&
+sleep 1
+
+migrateCmd="npm run migrate -- --network=development"
+echo "Running $migrateCmd"
+eval $migrateCmd
+unpauseCmd="truffle exec --network development scripts/unpauseController.js"
+echo "Running $unpauseCmd"
+eval $unpauseCmd
+controllerAddress=$(cd /protocol && truffle networks | awk '/54321/{f=1;next} /TokenPools/{f=0} f' | grep Controller | cut -d':' -f2 | tr -cd '[:alnum:]')
+echo "Controller address: $controllerAddress"
+truffle networks
+sleep 3
+
+cat <<EOF > /protocol/scripts/skipBlocks.js
+const RPC = require('../utils/rpc')
+
+module.exports = async cb => {
+    const rpc = new RPC(web3)
+    await rpc.wait(100)
+}
+EOF
+
+echo "Need to wait till second round - we can't initialize transcoders in first one"
+waitBlocksCmd="truffle exec --network development scripts/skipBlocks.js"
+echo "Running $waitBlocksCmd"
+eval $waitBlocksCmd
+
+echo "Good to go"
+sleep 1

--- a/ganache-with-protocol/build-ganache.sh
+++ b/ganache-with-protocol/build-ganache.sh
@@ -13,7 +13,7 @@ require("babel-polyfill")
 
 module.exports = {
     networks: {
-        development: {
+        lpTestNet: {
             host: "localhost",
             port: 8545,
             network_id: "54321", // Match any network id
@@ -48,23 +48,23 @@ module.exports = async cb => {
 EOF
 
 echo "npm install"
-npm install --unsafe-perm
+npm install 
 echo "Compiling contracts..."
 npm run compile
 echo "Done compiling, deploying..."
 
 echo "installing ganache"
-npm i ganache-cli -g --unsafe-perm
+npm i ganache-cli -g
 
 # Create truffle alias pointing to locally installed version
 alias truffle=./node_modules/.bin/truffle
-nohup bash -c "ganache-cli -k istanbul -l 0x7A1200 -h 0.0.0.0 -i 54321 --db $GANACHE_DB_PATH &" &&
+nohup bash -c "ganache-cli -k istanbul -l 0x7A1200 -h 0.0.0.0 -i 54321 -d --db $GANACHE_DB_PATH &" &&
 sleep 1
 
-migrateCmd="npm run migrate -- --network=development"
+migrateCmd="npm run migrate -- --network=lpTestNet"
 echo "Running $migrateCmd"
 eval $migrateCmd
-unpauseCmd="truffle exec --network development scripts/unpauseController.js"
+unpauseCmd="truffle exec --network lpTestNet scripts/unpauseController.js"
 echo "Running $unpauseCmd"
 eval $unpauseCmd
 controllerAddress=$(cd /protocol && truffle networks | awk '/54321/{f=1;next} /TokenPools/{f=0} f' | grep Controller | cut -d':' -f2 | tr -cd '[:alnum:]')
@@ -82,9 +82,12 @@ module.exports = async cb => {
 EOF
 
 echo "Need to wait till second round - we can't initialize transcoders in first one"
-waitBlocksCmd="truffle exec --network development scripts/skipBlocks.js"
+waitBlocksCmd="truffle exec --network lpTestNet scripts/skipBlocks.js"
 echo "Running $waitBlocksCmd"
 eval $waitBlocksCmd
 
 echo "Good to go"
+
+# shut down ganache-cli 
+pkill -9 node 
 sleep 1


### PR DESCRIPTION
This PR adds a docker file to create an image of ganache with the livepeer protocol. 

It follows largely the same build process as the `geth-with-protocol` image. 

An intermediate container runs ganache-cli and deploys the contracts. The ganache DB is then copied to the final container and used when the container is started (and ganache runs). 

Log excerpt
```
Listening on 0.0.0.0:8545
eth_accounts
rpc_modules
eth_newFilter
eth_getFilterLogs
eth_sendTransaction
```

