### PR TITLE
monitoring: Add -prometheus-kube-scrape flag

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -2,7 +2,7 @@ ARG ARCH="amd64"
 ARG OS="linux"
 
 FROM prom/prometheus:latest as t1
-FROM grafana/grafana:latest as c1
+FROM grafana/grafana:6.7.3 as c1
 
 FROM node:alpine as t2
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -21,6 +21,8 @@ a bundled prometheus/grafana container with a config templating for monitoring l
 
 - `--kube-namespaces` : comma separated list of namespaces to monitoring in the `kubernetes` deployment, this is needed for certain special deployments, it defaults to an empty array.
 
+- `--prometheus-kube-scrape`: string annotation for scraping a kube pod. Ex. If the value for this flag is `scrape_this_pod` then all kube pods to be scraped should have the annotation `prometheus.io/scrape_this_pod`. The value for this flag must follow the Prometheus requirements for naming and match the regex `[a-zA-Z_][a-zA-Z0-9_]*` (ACII letters, numbers and underscores).
+
 ### ENVs
 
 these env variables cannot be passed as a arg, this is because we use them in the simple docker templating for stuff like

--- a/monitoring/config-generator/src/generate.js
+++ b/monitoring/config-generator/src/generate.js
@@ -57,6 +57,11 @@ function generate () {
         default: 'http://localhost:9090',
         type: 'string'
       },
+      'prometheus-kube-scrape': {
+        describe: 'annotation for scraping Kubernetes pods',
+        default: 'scrape',
+        type: 'string'
+      },
       'cadvisor-port': {
         describe: '[docker compose mode only] the port defined for cadvisor',
         default: 8080,
@@ -157,7 +162,7 @@ function prometheusConfig (params) {
         break
       case 'kubernetes':
         const namespaces = (params.kubeNamespaces) ? params.kubeNamespaces.split(',') : null
-        obj.scrape_configs = getPromKubeJobs(namespaces)
+        obj.scrape_configs = getPromKubeJobs(namespaces, params.prometheusKubeScrape)
         if (params.kubeLongterm) {
           obj['remote_read'] = [{
             url: 'http://localhost:9201/read',
@@ -220,7 +225,7 @@ function prometheusConfig (params) {
   return obj
 }
 
-function getPromKubeJobs (namespaces) {
+function getPromKubeJobs (namespaces, promKubeScrape) {
   return [
     {
       "job_name": "kubernetes-apiservers",
@@ -320,7 +325,7 @@ function getPromKubeJobs (namespaces) {
       "relabel_configs": [
         {
           "source_labels": [
-            "__meta_kubernetes_pod_annotation_prometheus_io_scrape"
+            `__meta_kubernetes_pod_annotation_prometheus_io_${promKubeScrape}`
           ],
           "separator": ";",
           "regex": "true",
@@ -440,7 +445,7 @@ function getPromKubeJobs (namespaces) {
       "relabel_configs": [
         {
           "source_labels": [
-            "__meta_kubernetes_service_annotation_prometheus_io_scrape"
+            `__meta_kubernetes_service_annotation_prometheus_io_${promKubeScrape}`
           ],
           "separator": ";",
           "regex": "true",

--- a/monitoring/grafana/livepeer_overview.json
+++ b/monitoring/grafana/livepeer_overview.json
@@ -249,7 +249,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(up{livepeer_node_type=\"broadcaster\"})",
+          "expr": "sum(up{livepeer_node_type=~\"^.*broadcaster.*$\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -672,7 +672,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(up{livepeer_node_type=\"orchestrator\"})",
+          "expr": "sum(up{livepeer_node_type=~\"^.*orchestrator.*$\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION
This PR adds a `--prometheus-kube-scrape` flag to the monitoring container that allows the annotation used by Prometheus to determine which kube pods to scrape to be configured.

8a13cb1 fixes CI.
6c246bd is needed to properly count the # of Bs & Os when livepeer_node_type is rewritten to be the kube service name (i.e. staging-livepeer-orchestrator)