### PR TITLE
monitoring: Use overall transcode latency in Grafana

### DIFF
--- a/monitoring/config-generator/src/generate.js
+++ b/monitoring/config-generator/src/generate.js
@@ -635,7 +635,7 @@ function getRules(allowList) {
     name: 'transcoding-latency',
     rules: [{
         alert: '50-pct-latency-high',
-        expr: 'histogram_quantile(0.5, sum(rate(livepeer_transcode_latency_seconds_bucket[1m])) by ( le)) > 1',
+        expr: 'histogram_quantile(0.5, sum(rate(livepeer_transcode_overall_latency_seconds_bucket[1m])) by ( le)) > 1',
         for: '5m',
         annotations: {
           title: '50% transcoding latency is high',
@@ -647,7 +647,7 @@ function getRules(allowList) {
       },
       {
         alert: '90-pct-latency-high',
-        expr: 'histogram_quantile(0.9, sum(rate(livepeer_transcode_latency_seconds_bucket[1m])) by ( le)) > 2',
+        expr: 'histogram_quantile(0.9, sum(rate(livepeer_transcode_overall_latency_seconds_bucket[1m])) by ( le)) > 2',
         for: '2m',
         annotations: {
           title: '90% transcoding latency is high',
@@ -659,7 +659,7 @@ function getRules(allowList) {
       },
       {
         alert: '99-pct-latency-high',
-        expr: 'histogram_quantile(0.99, sum(rate(livepeer_transcode_latency_seconds_bucket[1m])) by ( le)) > 5',
+        expr: 'histogram_quantile(0.99, sum(rate(livepeer_transcode_overall_latency_seconds_bucket[1m])) by ( le)) > 5',
         for: '1m',
         annotations: {
           title: '99% transcoding latency is high',

--- a/monitoring/grafana/livepeer_overview.json
+++ b/monitoring/grafana/livepeer_overview.json
@@ -1010,7 +1010,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(livepeer_transcode_latency_seconds_bucket[1m])) by ( le))",
+          "expr": "histogram_quantile(0.99, sum(rate(livepeer_transcode_overall_latency_seconds_bucket[1m])) by ( le))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -1018,21 +1018,21 @@
           "refId": "D"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(livepeer_transcode_latency_seconds_bucket[1m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(livepeer_transcode_overall_latency_seconds_bucket[1m])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "95th",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.9, sum(rate(livepeer_transcode_latency_seconds_bucket[1m])) by ( le))",
+          "expr": "histogram_quantile(0.9, sum(rate(livepeer_transcode_overall_latency_seconds_bucket[1m])) by ( le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "90th",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.5, sum(rate(livepeer_transcode_latency_seconds_bucket[1m])) by ( le))",
+          "expr": "histogram_quantile(0.5, sum(rate(livepeer_transcode_overall_latency_seconds_bucket[1m])) by ( le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "50th",
@@ -1205,7 +1205,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(livepeer_transcode_latency_seconds_sum{node_type=\"bctr\"}[1m])) by (instance) / sum(rate(livepeer_transcode_latency_seconds_count{node_type=\"bctr\"}[1m])) by (instance)",
+          "expr": "sum(rate(livepeer_transcode_overall_latency_seconds_sum{node_type=\"bctr\"}[1m])) by (instance) / sum(rate(livepeer_transcode_overall_latency_seconds_count{node_type=\"bctr\"}[1m])) by (instance)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,


### PR DESCRIPTION
This PR updates the Grafana dashboards to use the `livepeer_transcode_overall_latency` metric instead of the `livepeer_transcode_latency` metric. The new metric measures the transcode latency starting when a segment emerges from the broadcaster and ending when *all* requested renditions are inserted into the playlist. Since the transcode latency measurement ends when all renditions are inserted into the playlist this metric will also include time spent on verification when a broadcaster is running in on-chain mode and working with untrusted orchestrators.

Fixes #28 