### PR TITLE
Add success-rate-low alert

### DIFF
--- a/monitoring/config-generator/src/generate.js
+++ b/monitoring/config-generator/src/generate.js
@@ -698,6 +698,25 @@ function getRules(allowList) {
 
   groups.push(transcodingLatency)
 
+  let successRate = {
+    name: 'success-rate',
+    rules: [{
+        alert: 'success-rate-low',
+        expr: '(sum(rate(livepeer_segment_transcoded_all_appeared_total[1m])) by (instance) / sum(rate(livepeer_segment_source_emerged_total[1m])) by (instance)) < 0.8',
+        for: '1m',
+        annotations: {
+          title: 'Success rate too low',
+          description: 'The success rate for instance {{ $labels.instance }} has dropped below 80%'
+        },
+        labels: {
+          severity: 'page'
+        }
+      }
+    ]
+  }
+
+  groups.push(successRate)
+
   if (allowList) {
     const allowed = allowList.split(',')
     groups = groups.filter(g => allowed.includes(g.name))


### PR DESCRIPTION
I tuned this to alert whenever success rate dips below 80% on a per instance basis. Easy to change of course.

@ya7ya how do you usually go about releasing this to stage so we can test?