### PR TITLE
Filter excessive UDP logs from mist

### DIFF
--- a/fluentd-tweaked/kubernetes.conf
+++ b/fluentd-tweaked/kubernetes.conf
@@ -225,3 +225,20 @@
     message ${record['log']}
   </record>
 </filter>
+
+# Drop excessive UDP logs from mist
+<filter kubernetes.**>
+  @type grep
+  <exclude>
+    key message
+    pattern /UDP data/
+  </exclude>
+</filter>
+<filter kubernetes.**>
+  @type grep
+  <exclude>
+    key message
+    pattern /UDP socket/
+  </exclude>
+</filter>
+


### PR DESCRIPTION
Finding the incantation that only processes "mist pod tagged" log messages would reduce CPU utilization, but this seems like a good first step.