### PR TITLE
monitoring: Update grafana dashboards

### DIFF
--- a/monitoring/grafana/livepeer_overview.json
+++ b/monitoring/grafana/livepeer_overview.json
@@ -1326,8 +1326,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(livepeer_segment_source_upload_failed_total[1m])) by (error_code)",
+          "expr": "sum(increase(livepeer_segment_source_upload_failed_total{error_code!=\"DuplicateSegment\"}[1m])) by (error_code)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{error_code}}",
           "refId": "A"
@@ -1417,9 +1418,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(livepeer_segment_transcode_failed_total[1m])) by (error_code)",
+          "expr": "sum(increase(livepeer_segment_transcode_failed_total{error_code!=\"DuplicateSegment\"}[1m])) by (error_code)",
           "format": "time_series",
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{error_code}}",
           "refId": "A"
@@ -1481,7 +1483,7 @@
         "y": 32
       },
       "hiddenSeries": false,
-      "id": 42,
+      "id": 56,
       "legend": {
         "avg": false,
         "current": false,
@@ -1493,7 +1495,6 @@
       },
       "lines": true,
       "linewidth": 1,
-      "links": [],
       "nullPointMode": "null",
       "options": {
         "dataLinks": []
@@ -1508,18 +1509,23 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(livepeer_transcode_retried[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{instance}} - try={{try}}",
+          "expr": "sum(increase(livepeer_segment_source_upload_failed_total{error_code=\"DuplicateSegment\"}[1m]))",
+          "interval": "",
+          "legendFormat": "UploadFailed",
           "refId": "A"
+        },
+        {
+          "expr": "sum(increase(livepeer_segment_transcode_failed_total{error_code=\"DuplicateSegment\"}[1m]))",
+          "interval": "",
+          "legendFormat": "TranscodeFailed",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Retries",
+      "title": "Duplicate Segments",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1662,7 +1668,7 @@
         "y": 40
       },
       "hiddenSeries": false,
-      "id": 22,
+      "id": 42,
       "legend": {
         "avg": false,
         "current": false,
@@ -1679,7 +1685,6 @@
       "options": {
         "dataLinks": []
       },
-      "paceLength": 10,
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -1690,10 +1695,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(livepeer_segment_source_upload_failed_total) by (instance, error_code)",
+          "expr": "rate(livepeer_transcode_retried[1m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}} {{error_code}}",
+          "legendFormat": "{{instance}} - try={{try}}",
           "refId": "A"
         }
       ],
@@ -1701,7 +1706,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Upload Errors Raw",
+      "title": "Retries",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1844,7 +1849,7 @@
         "y": 48
       },
       "hiddenSeries": false,
-      "id": 32,
+      "id": 22,
       "legend": {
         "avg": false,
         "current": false,
@@ -1872,23 +1877,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(livepeer_segment_source_appeared_total[30s])) - sum(increase(livepeer_segment_source_uploaded_total[30s]))\n",
+          "expr": "sum(livepeer_segment_source_upload_failed_total) by (instance, error_code)",
           "format": "time_series",
           "intervalFactor": 1,
+          "legendFormat": "{{instance}} {{error_code}}",
           "refId": "A"
-        },
-        {
-          "expr": "",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Not Uploaded Segments, rate",
+      "title": "Upload Errors Raw",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2020,7 +2020,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Percentage of segments transcoded faster than 3x realtime speed, 3x, 1x,  half realtime and more than two time slower than realtime",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2030,7 +2029,7 @@
         "y": 56
       },
       "hiddenSeries": false,
-      "id": 52,
+      "id": 32,
       "legend": {
         "avg": false,
         "current": false,
@@ -2042,55 +2041,39 @@
       },
       "lines": true,
       "linewidth": 1,
+      "links": [],
       "nullPointMode": "null",
       "options": {
         "dataLinks": []
       },
-      "percentage": true,
+      "paceLength": 10,
+      "percentage": false,
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(livepeer_http_client_segment_transcoded_realtime_3x[1m]))/sum(increase(livepeer_segment_source_emerged_unprocessed_total[1m]))",
-          "interval": "",
-          "legendFormat": "3x",
+          "expr": "sum(increase(livepeer_segment_source_appeared_total[30s])) - sum(increase(livepeer_segment_source_uploaded_total[30s]))\n",
+          "format": "time_series",
+          "intervalFactor": 1,
           "refId": "A"
         },
         {
-          "expr": "sum(increase(livepeer_http_client_segment_transcoded_realtime_2x[1m]))/sum(increase(livepeer_segment_source_emerged_unprocessed_total[1m]))",
-          "interval": "",
-          "legendFormat": "2x",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(increase(livepeer_http_client_segment_transcoded_realtime_1x[1m]))/sum(increase(livepeer_segment_source_emerged_unprocessed_total[1m]))",
-          "interval": "",
-          "legendFormat": "1x",
+          "expr": "",
+          "format": "time_series",
+          "intervalFactor": 1,
           "refId": "B"
-        },
-        {
-          "expr": "sum(increase(livepeer_http_client_segment_transcoded_realtime_half[1m]))/sum(increase(livepeer_segment_source_emerged_unprocessed_total[1m]))",
-          "interval": "",
-          "legendFormat": "half realtime",
-          "refId": "D"
-        },
-        {
-          "expr": "sum(increase(livepeer_http_client_segment_transcoded_realtime_slow[1m]))/sum(increase(livepeer_segment_source_emerged_unprocessed_total[1m]))",
-          "interval": "",
-          "legendFormat": "slow",
-          "refId": "E"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "HTTP push realtime ratio",
+      "title": "Not Uploaded Segments, rate",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2222,6 +2205,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "description": "Percentage of segments transcoded faster than 3x realtime speed, 3x, 1x,  half realtime and more than two time slower than realtime",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2231,7 +2215,7 @@
         "y": 64
       },
       "hiddenSeries": false,
-      "id": 54,
+      "id": 52,
       "legend": {
         "avg": false,
         "current": false,
@@ -2247,28 +2231,51 @@
       "options": {
         "dataLinks": []
       },
-      "percentage": false,
+      "percentage": true,
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(livepeer_orchestrator_swaps[1m]))",
-          "instant": false,
+          "expr": "sum(increase(livepeer_http_client_segment_transcoded_realtime_3x[1m]))/sum(increase(livepeer_segment_source_emerged_unprocessed_total[1m]))",
           "interval": "",
-          "legendFormat": "SwapsPerMinute",
+          "legendFormat": "3x",
           "refId": "A"
+        },
+        {
+          "expr": "sum(increase(livepeer_http_client_segment_transcoded_realtime_2x[1m]))/sum(increase(livepeer_segment_source_emerged_unprocessed_total[1m]))",
+          "interval": "",
+          "legendFormat": "2x",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(livepeer_http_client_segment_transcoded_realtime_1x[1m]))/sum(increase(livepeer_segment_source_emerged_unprocessed_total[1m]))",
+          "interval": "",
+          "legendFormat": "1x",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(livepeer_http_client_segment_transcoded_realtime_half[1m]))/sum(increase(livepeer_segment_source_emerged_unprocessed_total[1m]))",
+          "interval": "",
+          "legendFormat": "half realtime",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(increase(livepeer_http_client_segment_transcoded_realtime_slow[1m]))/sum(increase(livepeer_segment_source_emerged_unprocessed_total[1m]))",
+          "interval": "",
+          "legendFormat": "slow",
+          "refId": "E"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Orchestrator Swaps",
+      "title": "HTTP push realtime ratio",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2368,6 +2375,95 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Segments Number",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 72
+      },
+      "hiddenSeries": false,
+      "id": 54,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(livepeer_orchestrator_swaps[1m]))",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "SwapsPerMinute",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Orchestrator Swaps",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/monitoring/grafana/livepeer_overview.json
+++ b/monitoring/grafana/livepeer_overview.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 8,
+  "id": 3,
   "links": [],
   "panels": [
     {
@@ -2257,9 +2257,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(livepeer_orchestrator_swaps[5m])",
+          "expr": "sum(rate(livepeer_orchestrator_swaps[1m]))",
+          "instant": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "SwapsPerMinute",
           "refId": "A"
         }
       ],

--- a/monitoring/grafana/orchestrator_overview.json
+++ b/monitoring/grafana/orchestrator_overview.json
@@ -2,7 +2,6 @@
   "annotations": {
     "list": [
       {
-        "$$hashKey": "object:228",
         "builtIn": 1,
         "datasource": "-- Grafana --",
         "enable": true,
@@ -16,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 8,
+  "id": 3,
   "links": [],
   "panels": [
     {
@@ -49,12 +48,10 @@
       "mappingType": 1,
       "mappingTypes": [
         {
-          "$$hashKey": "object:340",
           "name": "value to text",
           "value": 1
         },
         {
-          "$$hashKey": "object:341",
           "name": "range to text",
           "value": 2
         }
@@ -99,7 +96,6 @@
       "valueFontSize": "80%",
       "valueMaps": [
         {
-          "$$hashKey": "object:343",
           "op": "=",
           "text": "N/A",
           "value": "null"
@@ -126,7 +122,7 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 6,
+        "h": 3,
         "w": 5,
         "x": 5,
         "y": 0
@@ -137,12 +133,10 @@
       "mappingType": 1,
       "mappingTypes": [
         {
-          "$$hashKey": "object:744",
           "name": "value to text",
           "value": 1
         },
         {
-          "$$hashKey": "object:745",
           "name": "range to text",
           "value": 2
         }
@@ -187,7 +181,6 @@
       "valueFontSize": "80%",
       "valueMaps": [
         {
-          "$$hashKey": "object:747",
           "op": "=",
           "text": "N/A",
           "value": "null"
@@ -265,7 +258,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:400",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -274,7 +266,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:401",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -340,6 +331,91 @@
       "timeShift": null,
       "title": "Orchestrator Utilization",
       "type": "gauge"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 5,
+        "y": 3
+      },
+      "id": 25,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "pluginVersion": "6.7.3",
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(livepeer_max_sessions_total{node_type=\"orch\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "# Orchestrator Sessions (Max)",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
     },
     {
       "aliasColors": {},
@@ -426,7 +502,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:314",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -435,7 +510,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:315",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -516,7 +590,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:93",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -525,7 +598,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:94",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -624,7 +696,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:208",
           "format": "s",
           "label": null,
           "logBase": 1,
@@ -633,7 +704,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:209",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -714,7 +784,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:360",
           "format": "s",
           "label": null,
           "logBase": 1,
@@ -723,7 +792,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:361",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -822,7 +890,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:117",
           "format": "s",
           "label": null,
           "logBase": 1,
@@ -831,7 +898,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:118",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -912,7 +978,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:581",
           "format": "s",
           "label": null,
           "logBase": 1,
@@ -921,7 +986,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:582",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1020,7 +1084,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:879",
           "format": "s",
           "label": null,
           "logBase": 1,
@@ -1029,7 +1092,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:880",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1110,7 +1172,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:962",
           "format": "s",
           "label": null,
           "logBase": 1,
@@ -1119,7 +1180,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:963",
           "format": "short",
           "label": null,
           "logBase": 1,


### PR DESCRIPTION
- https://github.com/livepeer/docker-livepeer/commit/3b79df71422738de95bf08542a4d43f546b3489e Sum the # of O swaps for all Bs into a combined chart (Fixes #52 )
![image](https://user-images.githubusercontent.com/1710825/106933789-587b2c80-673f-11eb-8726-b6a0ec086185.png)


- https://github.com/livepeer/docker-livepeer/commit/67df029a660460c78ad5f006664a7e88c281f536 Remove `DuplicateSegment` error from the Upload Failure and Transcode Failure charts, and move them into a separate Duplicate Segments chart
![image](https://user-images.githubusercontent.com/1710825/106933836-66c94880-673f-11eb-9610-707046d8a221.png)


- https://github.com/livepeer/docker-livepeer/pull/54/commits/db840f9a679fdcc924948a55416d9d2ea52bced2 Display max available # of O Sessions 
![image](https://user-images.githubusercontent.com/1710825/106934184-d4757480-673f-11eb-98b1-519789d63075.png)
