### PR TITLE
monitoring: Update real-time alert query

### DIFF
--- a/monitoring/config-generator/src/generate.js
+++ b/monitoring/config-generator/src/generate.js
@@ -668,7 +668,7 @@ function getRules(allowList) {
     rules: [
       {
         alert: 'real-time',
-        expr: '(sum(increase(livepeer_http_client_segment_transcoded_realtime_3x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_2x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_1x[1m]))) / (sum(increase(livepeer_http_client_segment_transcoded_realtime_3x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_2x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_1x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_half[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_slow[1m]))) < .97',
+        expr: '(sum(increase(livepeer_http_client_segment_transcoded_realtime_3x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_2x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_1x[1m]))) / (sum(increase(livepeer_http_client_segment_transcoded_realtime_3x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_2x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_1x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_half[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_slow[1m]))) < .99',
         for: '2m',
         annotations: {
           title: '% real-time or faster HTTP push requests is low',

--- a/monitoring/config-generator/src/generate.js
+++ b/monitoring/config-generator/src/generate.js
@@ -668,7 +668,7 @@ function getRules(allowList) {
     rules: [
       {
         alert: 'real-time',
-        expr: '(sum(increase(livepeer_http_client_segment_transcoded_realtime_3x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_2x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_1x[1m]))) / sum(increase(livepeer_segment_source_emerged_unprocessed_total[1m])) < .97',
+        expr: '(sum(increase(livepeer_http_client_segment_transcoded_realtime_3x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_2x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_1x[1m]))) / (sum(increase(livepeer_http_client_segment_transcoded_realtime_3x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_2x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_1x[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_half[1m])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_slow[1m]))) < .97',
         for: '2m',
         annotations: {
           title: '% real-time or faster HTTP push requests is low',


### PR DESCRIPTION
As discussed, do `sum(1x, 2x, 3x)/sum(1x, 2x, 3x, half, slow)` instead of using another metric for the totals

Also increase the threshold to `0.99` since the fixed metric seems to be really stable. If it stays too verbose
we can change it back to `0.97` or something else