### PR TITLE
geth-with-protocol/ganache-with-protocol fixes

### DIFF
--- a/ganache-with-protocol/build-ganache.sh
+++ b/ganache-with-protocol/build-ganache.sh
@@ -1,5 +1,7 @@
 git clone -b streamflow https://github.com/livepeer/protocol.git
 cd protocol
+# TODO: Update this file to be compatible with new deployment scripts in protocol repo
+git checkout d8e3523e3779a7f339b94159ad5d36ce428799cc
 echo "Setting devenv specific protocol parameters"
 pollCreator="/protocol/contracts/polling/PollCreator.sol"
 sed -i 's/10 rounds.*$/7 rounds/' $pollCreator

--- a/geth-with-protocol/Dockerfile
+++ b/geth-with-protocol/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.9.11 as builder-geth
+FROM ethereum/client-go:v1.10.8 as builder-geth
 
 WORKDIR /
 ENV gethRoot /root/.ethereum

--- a/geth-with-protocol/build-protocol.sh
+++ b/geth-with-protocol/build-protocol.sh
@@ -3,6 +3,8 @@ mkdir /psrc && cd /psrc
 git clone -b streamflow https://github.com/livepeer/protocol.git
 srcDir=/psrc
 cd $srcDir/protocol
+# TODO: Update this file to be compatible with new deployment scripts in protocol repo
+git checkout d8e3523e3779a7f339b94159ad5d36ce428799cc
 echo "Setting devenv specific protocol parameters"
 migrations="$srcDir/protocol/migrations/migrations.config.js"
 sed -i 's/roundLength:.*$/roundLength: 50,/' $migrations

--- a/geth-with-protocol/genesis.json
+++ b/geth-with-protocol/genesis.json
@@ -10,6 +10,8 @@
     "constantinopleBlock": 0,
     "petersburgBlock": 0,
     "istanbulBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
     "clique": {
       "period": 1,
       "epoch": 30000

--- a/geth-with-protocol/start.sh
+++ b/geth-with-protocol/start.sh
@@ -1,12 +1,13 @@
-geth -networkid 54321 -rpc -ws \
-      -rpcaddr "0.0.0.0" -wsaddr "0.0.0.0" \
-      -rpccorsdomain "*" -wsorigins "*" \
-      -rpcapi 'personal,account,eth,web3,net,txpool,miner,debug' \
-      -wsapi 'personal,account,eth,web3,net,txpool,miner,debug' \
+geth -networkid 54321 -http -ws \
+      -http.addr "0.0.0.0" -ws.addr "0.0.0.0" \
+      -http.corsdomain "*" -ws.origins "*" \
+      -http.vhosts="*" \
+      -http.api 'personal,eth,web3,net,txpool,miner,debug' \
+      -ws.api 'personal,eth,web3,net,txpool,miner,debug' \
       --unlock '0161e041aad467a890839d5b08b138c1e6373072,87da6a8c6e9eff15d703fc2773e32f6af8dbe301,b97de4b8c857e4f6bc354f226dc3249aaee49209,c5065c9eeebe6df2c2284d046bfc906501846c51' \
       --password $gethRoot/password.txt \
       --nodiscover --maxpeers 0 \
-      --targetgaslimit 0x8000000 \
+      --miner.gaslimit 0x8000000 \
       --cache=512 \
       -mine -verbosity 2 \
-      --allow-insecure-unlock -gcmode "archive" -syncmode "full" --rpcvhosts="*" \
+      --allow-insecure-unlock -gcmode "archive" -syncmode "full" \


### PR DESCRIPTION
- Upgrade geth to v1.10.8 for geth-with-protocol
- Temp checkout an older commit (pre-Hardhat) from the protocol repo for both geth-with-protocol and ganache-with-protocol since more changes are needed for the new deploy script used in the protocol repo