### PR TITLE
config-generator: Split real-time alert into low and high priority versions

### DIFF
--- a/monitoring/config-generator/src/generate.js
+++ b/monitoring/config-generator/src/generate.js
@@ -686,8 +686,21 @@ function getRules(allowList) {
 
   groups.push(broadcastingFunds)
 
-  const realTimeQuery = (range, threshold) =>
-      `(sum(increase(livepeer_http_client_segment_transcoded_realtime_3x[${range}])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_2x[${range}])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_1x[${range}]))) / (sum(increase(livepeer_http_client_segment_transcoded_realtime_3x[${range}])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_2x[${range}])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_1x[${range}])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_half[${range}])) + sum(increase(livepeer_http_client_segment_transcoded_realtime_slow[${range}]))) < ${threshold}`
+  const realTimeTranscodesCount = (bucket, range) =>
+      `sum(increase(livepeer_http_client_segment_transcoded_realtime_${bucket}[${range}]))`
+  const realTimeQuery = (range, threshold) => `\
+(
+    ${realTimeTranscodesCount('3x', range)} +
+    ${realTimeTranscodesCount('2x', range)} +
+    ${realTimeTranscodesCount('1x', range)}
+) / (
+    ${realTimeTranscodesCount('3x', range)} +
+    ${realTimeTranscodesCount('2x', range)} +
+    ${realTimeTranscodesCount('1x', range)} +
+    ${realTimeTranscodesCount('half', range)} +
+    ${realTimeTranscodesCount('slow', range)}
+) < ${threshold}`
+
   let httpRealTimeRatioLopri = {
     name: 'http-real-time-ratio-lopri',
     rules: [


### PR DESCRIPTION
This is an attempt to improve our alerts verbosity, specifically the HTTP push real-time alert.

I would be grateful if anyone has any ideas/experience on how to test this before merging/deploying
to staging/prod.

Steps were:
 - Make the current version of the alert actually **low** priority, so don't we won't wake up or 
 urgently call an engineer for small blips in real-time ratio that recover themselves quickly. This
 one will keep alerting on **real-time ratio < 99% over 1 minute**.
 - Create a new version of the alert instead that actually sends a high urgency ("high priority")
 notification on pagerduty as before. This one has a much lower sensitivity for higher accuracy
 on detecting real incidents: This one will only alert when **real-time ratio < 90% over 10 minutes**

Yet to configure livepeer-infra (?) with the PagerDuty service key for the low-priority alerts. 