### PR TITLE
updated the geth-with-protocol docker to use the confluence branch an…

### DIFF
--- a/geth-with-protocol/Dockerfile
+++ b/geth-with-protocol/Dockerfile
@@ -9,7 +9,7 @@ RUN echo "" > /geth/password.txt
 RUN geth --datadir $gethRoot init /geth/genesis.json
 RUN cp /geth/keys/* $gethRoot/keystore/
 
-FROM node:10-alpine as builder-node
+FROM node:14.4.0-alpine as builder-node
 ENV gethRoot /root/.ethereum
 ENV GETH_MINING_ACCOUNT 0161e041aad467a890839d5b08b138c1e6373072
 

--- a/geth-with-protocol/README.md
+++ b/geth-with-protocol/README.md
@@ -5,10 +5,10 @@ A private, single-node (Geth) PoA Ethereum network with the Livepeer protocol co
 ## Usage
 
 ```
-docker run -d -p 8545:8545 -p 8546:8546 --name geth-with-livepeer-protocol livepeer/geth-with-livepeer-protocol:pm
+docker run -d -p 8545:8545 -p 8546:8546 --name geth-with-livepeer-protocol livepeer/geth-with-livepeer-protocol:confluence
 ```
 
-This command will download the latest version of the `livepeer/geth-with-livepeer-protocol:pm` container hosted on [DockerHub](https://hub.docker.com/r/livepeer/geth-with-livepeer-protocol).
+This command will download the latest version of the `livepeer/geth-with-livepeer-protocol:confluence` container hosted on [DockerHub](https://hub.docker.com/r/livepeer/geth-with-livepeer-protocol).
 
 ## Build
 

--- a/geth-with-protocol/build-protocol.sh
+++ b/geth-with-protocol/build-protocol.sh
@@ -1,89 +1,31 @@
 mkdir /psrc && cd /psrc
 
-git clone -b streamflow https://github.com/livepeer/protocol.git
+# to be changed after rb/hardhat-geth-config is merged with the confluence branch
+git clone -b rb/hardhat-geth-config https://github.com/livepeer/protocol.git
 srcDir=/psrc
 cd $srcDir/protocol
-# TODO: Update this file to be compatible with new deployment scripts in protocol repo
-git checkout d8e3523e3779a7f339b94159ad5d36ce428799cc
-echo "Setting devenv specific protocol parameters"
-migrations="$srcDir/protocol/migrations/migrations.config.js"
-sed -i 's/roundLength:.*$/roundLength: 50,/' $migrations
-sed -i 's/unlockPeriod:.*$/unlockPeriod: 50,/' $migrations
-sed -i 's/numActiveTranscoders:.*$/numActiveTranscoders: 50,/' $migrations
-sed -i 's/numTranscoders:.*$/numTranscoders: 100,/' $migrations
-
-cat << EOF > $srcDir/protocol/truffle.js
-require("babel-register")
-require("babel-polyfill")
-
-module.exports = {
-    networks: {
-        development: {
-            host: "localhost",
-            port: 8545,
-            network_id: "*", // Match any network id
-            gas: 8000000
-        },
-        lpTestNet: {
-            from: "0x$GETH_MINING_ACCOUNT",
-            host: "localhost",
-            port: 8545,
-            network_id: 54321,
-            gas: 8000000
-        }
-    },
-    compilers: {
-        solc: {
-            version: "0.5.11",
-            parser: "solcjs",
-            settings: {
-                optimizer: {
-                    enabled: true,
-                    runs: 200
-                }
-            }
-        }
-    }
-};
-EOF
-
-echo "Installing local dev version of $srcDir/protocol/scripts/unpauseController.js"
-
-cat <<EOF > $srcDir/protocol/scripts/unpauseController.js
-const Controller = artifacts.require("Controller")
-
-module.exports = async cb => {
-    const controller = await Controller.deployed()
-    await controller.unpause({from: "0x$GETH_MINING_ACCOUNT"})
-    cb()
-}
-EOF
-
-echo "npm install"
-npm install
-echo "Compiling contracts..."
-npm run compile
-echo "Done compiling, deploying..."
-
-# Create truffle alias pointing to locally installed version
-alias truffle=./node_modules/.bin/truffle
 
 nohup bash -c "/start.sh &" &&
 sleep 1
 
 OPWD=$PWD
 cd $srcDir/protocol
-migrateCmd="npm run migrate -- --network=lpTestNet"
+echo "yarn install"
+yarn install
+echo "npx hardhat typechain"
+npx hardhat typechain
+migrateCmd="yarn deploy --network geth"
 echo "Running $migrateCmd"
 eval $migrateCmd
-unpauseCmd="truffle exec --network lpTestNet scripts/unpauseController.js"
+unpauseCmd="npx hardhat unpause --network geth"
 echo "Running $unpauseCmd"
 eval $unpauseCmd
-controllerAddress=$(cd $srcDir/protocol && truffle networks | awk '/54321/{f=1;next} /TokenPools/{f=0} f' | grep Controller | cut -d':' -f2 | tr -cd '[:alnum:]')
+controllerAddress=$(npx hardhat print-contract-address --contract Controller --network geth)
 echo "Controller address: $controllerAddress"
-truffle networks
-truffle networks > $gethRoot/networks
 echo $controllerAddress > $gethRoot/controllerAddress
+migrateArbitrumLPTMockCmd="npx hardhat deploy --tags ARBITRUM_LPT_MOCK --network geth"
+echo "Running $migrateArbitrumLPTMockCmd"
+eval $migrateArbitrumLPTMockCmd
 cd $OPWD
 sleep 3
 # now we need to wait till 100 block mined (so current protocol round will be 2)

--- a/geth-with-protocol/build-protocol.sh
+++ b/geth-with-protocol/build-protocol.sh
@@ -1,10 +1,10 @@
 mkdir /psrc && cd /psrc
 
-# to be changed after rb/hardhat-geth-config is merged with the confluence branch
-git clone -b rb/hardhat-geth-config https://github.com/livepeer/protocol.git
+git clone -b confluence https://github.com/livepeer/protocol.git
 srcDir=/psrc
 cd $srcDir/protocol
 
+git checkout 3c01f3a3e8c494ea2f89b77d03eb0a68a4e15518
 nohup bash -c "/start.sh &" &&
 sleep 1
 

--- a/geth-with-protocol/build-protocol.sh
+++ b/geth-with-protocol/build-protocol.sh
@@ -14,16 +14,16 @@ echo "yarn install"
 yarn install
 echo "npx hardhat typechain"
 npx hardhat typechain
-migrateCmd="yarn deploy --network geth"
+migrateCmd="yarn deploy --network gethDev"
 echo "Running $migrateCmd"
 eval $migrateCmd
-unpauseCmd="npx hardhat unpause --network geth"
+unpauseCmd="npx hardhat unpause --network gethDev"
 echo "Running $unpauseCmd"
 eval $unpauseCmd
-controllerAddress=$(npx hardhat print-contract-address --contract Controller --network geth)
+controllerAddress=$(npx hardhat print-contract-address --contract Controller --network gethDev)
 echo "Controller address: $controllerAddress"
 echo $controllerAddress > $gethRoot/controllerAddress
-migrateArbitrumLPTMockCmd="npx hardhat deploy --tags ARBITRUM_LPT_MOCK --network geth"
+migrateArbitrumLPTMockCmd="npx hardhat deploy --tags ARBITRUM_LPT_MOCK --network gethDev"
 echo "Running $migrateArbitrumLPTMockCmd"
 eval $migrateArbitrumLPTMockCmd
 cd $OPWD

--- a/geth-with-protocol/build-protocol.sh
+++ b/geth-with-protocol/build-protocol.sh
@@ -23,7 +23,7 @@ eval $unpauseCmd
 controllerAddress=$(npx hardhat print-contract-address --contract Controller --network gethDev)
 echo "Controller address: $controllerAddress"
 echo $controllerAddress > $gethRoot/controllerAddress
-migrateArbitrumLPTMockCmd="npx hardhat deploy --tags ARBITRUM_LPT_MOCK --network gethDev"
+migrateArbitrumLPTMockCmd="npx hardhat deploy --tags ARBITRUM_LPT_DUMMIES --network gethDev"
 echo "Running $migrateArbitrumLPTMockCmd"
 eval $migrateArbitrumLPTMockCmd
 cd $OPWD

--- a/geth-with-protocol/build.sh
+++ b/geth-with-protocol/build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build --rm -t livepeer/geth-with-livepeer-protocol:streamflow .
+docker build --rm -t livepeer/geth-with-livepeer-protocol:confluence .


### PR DESCRIPTION
**What does this pull request do?**
Updates the dockerfile and the build script of the protocol-with-geth docker in order to run the confluence version of the livepeer protocol with hardhat rather than truffle

**Does this pull request close any open issues?**
https://github.com/livepeer/go-livepeer/issues/2315

**TODO**
This line needs to be updated to point to the correct branch once the the related [PR](https://github.com/livepeer/protocol/pull/557) on the livepeer-protocol repo will be merged
https://github.com/livepeer/docker-livepeer/blob/ee511758cf552c6022cc61a875a8fb6de81e0f9b/geth-with-protocol/build-protocol.sh#L3-L4