### PR TITLE
geth-with-protocol: modified CI to support multiarch docker builds

### DIFF
--- a/.github/buildkitd.toml
+++ b/.github/buildkitd.toml
@@ -1,0 +1,2 @@
+[worker.oci]
+    max-parallelism = 1

--- a/.github/workflows/geth-with-protocol.yml
+++ b/.github/workflows/geth-with-protocol.yml
@@ -5,23 +5,26 @@ jobs:
   docker:
     runs-on: ubuntu-20.04
     steps:
-      - name: docker login
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          # docker login
-          docker version
-          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Check out code
         uses: actions/checkout@v1
 
-      - name: docker build
-        run: |
-          cd geth-with-protocol
-          docker build -t livepeer/geth-with-livepeer-protocol:confluence .
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
-      - name: docker push
-        run: |
-          docker push livepeer/geth-with-livepeer-protocol:confluence
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./geth-with-protocol
+          platforms: linux/arm64, linux/amd64
+          push: true
+          tags: livepeer/geth-with-livepeer-protocol:confluence

--- a/.github/workflows/geth-with-protocol.yml
+++ b/.github/workflows/geth-with-protocol.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          config: .github/buildkitd.toml
 
       - name: Build and push
         uses: docker/build-push-action@v3

--- a/geth-with-protocol/build-protocol.sh
+++ b/geth-with-protocol/build-protocol.sh
@@ -12,6 +12,8 @@ OPWD=$PWD
 cd $srcDir/protocol
 echo "yarn config set unsafe-perm true"
 yarn config set unsafe-perm true
+echo "npm config set unsafe-perm=true"
+npm config set unsafe-perm=true
 echo "yarn install"
 yarn install
 echo "npx hardhat typechain"

--- a/geth-with-protocol/build-protocol.sh
+++ b/geth-with-protocol/build-protocol.sh
@@ -6,10 +6,12 @@ cd $srcDir/protocol
 
 git checkout 3c01f3a3e8c494ea2f89b77d03eb0a68a4e15518
 nohup bash -c "/start.sh &" &&
-sleep 1
+sleep 4
 
 OPWD=$PWD
 cd $srcDir/protocol
+echo "yarn config set unsafe-perm true"
+yarn config set unsafe-perm true
 echo "yarn install"
 yarn install
 echo "npx hardhat typechain"


### PR DESCRIPTION
**Context**
It adds multiarch docker builds support to the geth-with-protocol github action

**Related issue**
https://github.com/livepeer/go-livepeer/issues/2316